### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,12 +140,12 @@ jobs:
       - name: Cleanup
         run: sudo apt clean && sudo apt autoclean && sudo apt autoremove -y
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.0.0
         with:
           cmakeVersion: 3.30.6
           ninjaVersion: latest
       - name: Install GraalVM JDK 23
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v4.7.0
         with:
           distribution: 'graalvm'
           java-version: '23'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[lukka/get-cmake](https://github.com/lukka/get-cmake)** published a new release **[v4.0.0](https://github.com/lukka/get-cmake/releases/tag/v4.0.0)** on 2025-03-28T08:39:54Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.7.0](https://github.com/actions/setup-java/releases/tag/v4.7.0)** on 2025-01-29T03:24:46Z
